### PR TITLE
Add script for sheet music accompaniment generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-.
+# Sheet Music Accompaniment Generator
+
+This repository contains a Python script for generating a simple piano accompaniment from scanned sheet music.
+
+The script uses optical music recognition via the `oemer` library to convert images or PDFs of scores into MusicXML, analyzes the chords with `music21`, and outputs a new score with a basic accompaniment part.
+
+## Usage
+
+```
+python3 sheet_accompaniment.py path/to/score.pdf
+```
+
+Outputs `output.mid` and `output_with_accompaniment.musicxml` in the current directory.

--- a/sheet_accompaniment.py
+++ b/sheet_accompaniment.py
@@ -1,0 +1,89 @@
+import os
+from typing import List
+
+from pdf2image import convert_from_path
+from oemer import Oemer
+import music21 as m21
+
+
+def convert_pdf_to_images(pdf_path: str, output_dir: str = "pdf_pages") -> List[str]:
+    """Convert a PDF into a list of image paths."""
+    os.makedirs(output_dir, exist_ok=True)
+    pages = convert_from_path(pdf_path)
+    image_paths = []
+    for i, page in enumerate(pages):
+        img_path = os.path.join(output_dir, f"page_{i + 1}.png")
+        page.save(img_path, "PNG")
+        image_paths.append(img_path)
+    return image_paths
+
+
+def run_omr_on_images(image_paths: List[str], output_xml: str = "score.musicxml") -> str:
+    """Run Optical Music Recognition on the given images."""
+    oemer = Oemer()
+    oemer.process(image_paths, output_xml)
+    return output_xml
+
+
+def generate_chord_accompaniment(score: m21.stream.Score) -> m21.stream.Part:
+    """Generate a simple piano accompaniment part from the chords of the score."""
+    chords = score.chordify()
+    piano_part = m21.stream.Part()
+    piano_part.insert(0, m21.instrument.Piano())
+
+    for measure in chords.measures(0, None):
+        measure_chords = measure.getElementsByClass(m21.chord.Chord)
+        if not measure_chords:
+            # Insert a rest if no harmony was detected
+            rest = m21.note.Rest()
+            rest.duration = m21.duration.Duration(4)
+            piano_part.append(rest)
+            continue
+        # Use the first chord found in the measure
+        chord = measure_chords[0]
+        new_chord = m21.chord.Chord(chord.pitches)
+        new_chord.duration = m21.duration.Duration(4)  # whole note
+        piano_part.append(new_chord)
+    return piano_part
+
+
+def create_accompanied_score(score: m21.stream.Score) -> m21.stream.Score:
+    """Combine the original score with a generated accompaniment."""
+    piano_part = generate_chord_accompaniment(score)
+    combined = m21.stream.Score()
+    for part in score.parts:
+        combined.append(part)
+    combined.append(piano_part)
+    return combined
+
+
+def process_input(input_path: str) -> m21.stream.Score:
+    """Full pipeline: OCR/OMR the input and generate accompaniment."""
+    _, ext = os.path.splitext(input_path)
+    if ext.lower() == ".pdf":
+        image_paths = convert_pdf_to_images(input_path)
+    else:
+        image_paths = [input_path]
+    xml_path = run_omr_on_images(image_paths)
+    score = m21.converter.parse(xml_path)
+    accompanied = create_accompanied_score(score)
+    return accompanied
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Generate playback and chord accompaniment from sheet music")
+    parser.add_argument("input", help="Path to sheet music image or PDF")
+    parser.add_argument("--midi", default="output.mid", help="Path for output MIDI file")
+    parser.add_argument("--xml", default="output_with_accompaniment.musicxml", help="Path for output MusicXML file")
+    args = parser.parse_args()
+
+    score = process_input(args.input)
+    score.write("midi", fp=args.midi)
+    score.write("musicxml", fp=args.xml)
+    print(f"Saved MIDI to {args.midi} and MusicXML to {args.xml}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a Python script that uses `oemer` and `music21` to extract sheet music from images or PDFs and create a piano accompaniment
- document usage instructions in README

## Testing
- `python3 -m py_compile sheet_accompaniment.py`
- `python3 sheet_accompaniment.py --help` *(fails: ModuleNotFoundError: No module named 'pdf2image')*


------
https://chatgpt.com/codex/tasks/task_e_6862abc0a0048324889fe32734041faa